### PR TITLE
Enhance visibility of spamcheck logs

### DIFF
--- a/src/dispatcher.py
+++ b/src/dispatcher.py
@@ -1322,7 +1322,7 @@ async def tg_ai_spamcheck(update, context):
                 "",
                 "╔═ AI-Spamcheck",
                 f"║ Probability  : {vis_emoji} {spam_prob:.5f}  (del≥{delete_thr}, mute≥{mute_thr})",
-                f"╚═ Content     : {short_txt}",
+                f"╚═ 📝 Content   : {short_txt}",
                 f"            ↳ User: {user_ment}",
                 f"            ↳ Chat: {chat_name} ({chat_id})",
                 f"            ↳ Action: {action}",


### PR DESCRIPTION
## Summary
- show a memo emoji next to Content in spamcheck logs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: telethon)*

------
https://chatgpt.com/codex/tasks/task_e_684382f3dcd88323bc4d9208b382952b